### PR TITLE
Adds custom Header to CE DSL

### DIFF
--- a/src/FsHttp/DslCE.fs
+++ b/src/FsHttp/DslCE.fs
@@ -162,6 +162,11 @@ module DslCE =
         member this.From (context, email) =
             Dsl.H.from context email id
         
+        /// Custom header
+        [<CustomOperation("Header")>]
+        member this.Header (context, key, value) =
+            Dsl.H.header key value context id
+
         /// The domain name of the server (for virtual hosting), and the TCP port number on which the server is listening.
         /// The port number may be omitted if the port is the standard port for the service requested.
         [<CustomOperation("Host")>]

--- a/src/Tests/IntegrationTests.fs
+++ b/src/Tests/IntegrationTests.fs
@@ -178,6 +178,26 @@ let ``Cookies can be sent``() =
     |> should equal "hello world"
 
 
+[<TestCase>]
+let ``Custom Headers``() =
+    let customHeaderKey = "X-Custom-Value"
+
+    use server =
+        GET
+        >=> request (fun r ->
+            r.header customHeaderKey
+            |> function | Choice1Of2 v -> v | Choice2Of2 e -> failwithf "Failed %s" e
+            |> OK)
+        |> serve
+
+    http {
+        GET (url @"")
+        Header customHeaderKey "hello world"
+    }
+    |> toText
+    |> should equal "hello world"
+
+
 // [<TestCase>]
 // let ``Http reauest message can be modified``() =
 //     use server = GET >=> request (header "accept-language" >> OK) |> serve


### PR DESCRIPTION
I noticed the CE DSL was missing the ability to add custom headers. 