### PR TITLE
Changed documentation build process to create `README.md` instead of `Readme.md`

### DIFF
--- a/docu.fsx
+++ b/docu.fsx
@@ -48,5 +48,5 @@ let linesWhereTrailingEmptyCodeLinesRemoved script =
 let generate () =
     let source = __SOURCE_DIRECTORY__
     let script = Path.Combine(source, "./src/Docu/Demo.DslCE.fsx")
-    let readme = Path.Combine(source, "./Readme.md")
+    let readme = Path.Combine(source, "./README.md")
     File.WriteAllLines(readme, linesWhereTrailingEmptyCodeLinesRemoved script)

--- a/src/Docu/Demo.DslCE.fsx
+++ b/src/Docu/Demo.DslCE.fsx
@@ -24,10 +24,10 @@ You need to have dotnet SDK 3.1.202 installed (as specified in global.json).
 
 Have a look at these files for more use cases:
 
-* [Demo script for CE Dsl](src/Samples/Demo.DslCE.fsx)
+* [Demo script for CE Dsl](src/Docu/Demo.DslCE.fsx)
   This file demonstrates the use of the CE (computation expression) syntax.
 
-* [Demo script for op-less Dsl](src/Samples/Demo.Dsl.fsx)
+* [Demo script for op-less Dsl](src/Docu/Demo.Dsl.fsx)
   This file demonstrates the use of pipe-style syntax.
 
 * [Integration Tests](src/Tests/IntegrationTests.fs)


### PR DESCRIPTION
I tried building the readme file by using `dotnet fsi .\build.fsx docu` but that resulted in me having to readme files:
1. `README.md` which was tracked by git and unmodified
2. `Readme.md` which was newly generated.
This is probably because I am using a case sensitive filesystem. I've changed the output file in `docu.fsx` from `Readme.md` to `README.md`.