### PR TITLE
Update README to include information on correct package and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 
-FsHttp
+SchlenkR.FsHttp
 ======
 
 FsHttp is a convenient HTTP client library written in F#. It aims for describing and executing HTTP requests in idiomatic and convenient ways that can be used for production, tests and FSI (F# Interactive).
 
 [![NuGet Badge](http://img.shields.io/nuget/v/SchlenkR.FsHttp.svg?style=flat)](https://www.nuget.org/packages/SchlenkR.FsHttp) [![Build Status](https://travis-ci.org/ronaldschlenker/FsHttp.svg?branch=master)](https://travis-ci.org/ronaldschlenker/FsHttp)
 
+**NOTE**: [FsHttp](https://www.nuget.org/packages/FsHttp) is *depricated*. Please use the package [SchlenkR.FsHttp](https://www.nuget.org/packages/SchlenkR.FsHttp) in the future
 
 Documentation
 -------------
@@ -19,6 +20,12 @@ A Simple Example
 ----------------
 
 ```fsharp
+
+#r "nuget: SchlenkR.FsHttp"
+
+open FsHttp
+open FsHttp.DslCE
+
 http {
     POST "https://reqres.in/api/users"
     CacheControl "no-cache"


### PR DESCRIPTION
I discovered this library through a [tweet](https://twitter.com/_cartermp/status/1450550390563295234), but realized when I went to install this package in a NuGet explorer the referenced tweet was installing a [deprecated and unlisted package](https://www.nuget.org/packages/FsHttp) and the repo didn't mention the [current package](https://www.nuget.org/packages/SchlenkR.FsHttp). It also didn't add the additional namespace in the simple example making discoverability harder. The updates to the README should make the next new person attempting to use this to not have to jump through as many hoops as I did.

FWIW, I liked the NuGet package better as **FsHttp** because it's harder to find in a nuget explorer (looking up just FsHttp didn't show up until after I installed the package, and I have a harder time trying to remember what your last name is when I just want use it in an F# script) though I do understand the convention and it's nice to have something cool with your name on it. 

Nice library! 👍 